### PR TITLE
feat: allow setting min TLS version for web socket  WPB-4260

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -116,11 +116,11 @@ open class WebSocket: WebSocketClient, EngineDelegate {
         self.engine = engine
     }
     
-    public convenience init(request: URLRequest, certPinner: CertificatePinning? = FoundationSecurity(), compressionHandler: CompressionHandler? = nil, useCustomEngine: Bool = true) {
+    public convenience init(request: URLRequest, certPinner: CertificatePinning? = FoundationSecurity(), compressionHandler: CompressionHandler? = nil, useCustomEngine: Bool = true, useTLS12OrGreater: Bool = false) {
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), !useCustomEngine {
-            self.init(request: request, engine: NativeEngine())
+            self.init(request: request, engine: NativeEngine(useTLS12OrGreater: useTLS12OrGreater))
         } else if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            self.init(request: request, engine: WSEngine(transport: TCPTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
+            self.init(request: request, engine: WSEngine(transport: TCPTransport(useTLS12OrGreater: useTLS12OrGreater), certPinner: certPinner, compressionHandler: compressionHandler))
         } else {
             self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
         }

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -87,6 +87,45 @@ public enum WebSocketEvent {
     case cancelled
 }
 
+public enum TLSVersion: Int {
+
+    case v1_0
+    case v1_1
+    case v1_2
+    case v1_3
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    init?(_ secValue: tls_protocol_version_t) {
+        switch secValue {
+        case .TLSv10:
+            self = .v1_0
+        case .TLSv11:
+            self = .v1_1
+        case .TLSv12:
+            self = .v1_2
+        case .TLSv13:
+            self = .v1_3
+        default:
+            return nil
+        }
+    }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    var secValue: tls_protocol_version_t {
+        switch self {
+        case .v1_0:
+            return .TLSv10
+        case .v1_1:
+            return .TLSv11
+        case .v1_2:
+            return .TLSv12
+        case .v1_3:
+            return .TLSv13
+        }
+    }
+
+}
+
 public protocol WebSocketDelegate: AnyObject {
     func didReceive(event: WebSocketEvent, client: WebSocketClient)
 }
@@ -116,11 +155,11 @@ open class WebSocket: WebSocketClient, EngineDelegate {
         self.engine = engine
     }
     
-    public convenience init(request: URLRequest, certPinner: CertificatePinning? = FoundationSecurity(), compressionHandler: CompressionHandler? = nil, useCustomEngine: Bool = true, useTLS12OrGreater: Bool = false) {
+    public convenience init(request: URLRequest, certPinner: CertificatePinning? = FoundationSecurity(), compressionHandler: CompressionHandler? = nil, useCustomEngine: Bool = true, minTLSVersion: TLSVersion? = nil) {
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), !useCustomEngine {
-            self.init(request: request, engine: NativeEngine(useTLS12OrGreater: useTLS12OrGreater))
+            self.init(request: request, engine: NativeEngine(minTLSVersion: minTLSVersion))
         } else if #available(macOS 10.14, iOS 12.0, watchOS 5.0, tvOS 12.0, *) {
-            self.init(request: request, engine: WSEngine(transport: TCPTransport(useTLS12OrGreater: useTLS12OrGreater), certPinner: certPinner, compressionHandler: compressionHandler))
+            self.init(request: request, engine: WSEngine(transport: TCPTransport(minTLSVersion: minTLSVersion), certPinner: certPinner, compressionHandler: compressionHandler))
         } else {
             self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
         }

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -35,7 +35,7 @@ public class TCPTransport: Transport {
     private weak var delegate: TransportEventClient?
     private var isRunning = false
     private var isTLS = false
-    private var useTLS12OrGreater = false
+    private var minTLSVersion: TLSVersion?
     
     public var usingTLS: Bool {
         return self.isTLS
@@ -46,8 +46,8 @@ public class TCPTransport: Transport {
         start()
     }
     
-    public init(useTLS12OrGreater: Bool = false) {
-        self.useTLS12OrGreater = useTLS12OrGreater
+    public init(minTLSVersion: TLSVersion? = nil) {
+        self.minTLSVersion = minTLSVersion
         //normal connection, will use the "connect" method below
     }
 
@@ -62,8 +62,8 @@ public class TCPTransport: Transport {
 
         let tlsOptions = isTLS ? NWProtocolTLS.Options() : nil
         if let tlsOpts = tlsOptions {
-            if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), useTLS12OrGreater {
-                sec_protocol_options_set_min_tls_protocol_version(tlsOpts.securityProtocolOptions, .TLSv12)
+            if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), let minTLSVersion = minTLSVersion {
+                sec_protocol_options_set_min_tls_protocol_version(tlsOpts.securityProtocolOptions, minTLSVersion.secValue)
             }
 
             sec_protocol_options_set_verify_block(tlsOpts.securityProtocolOptions, { (sec_protocol_metadata, sec_trust, sec_protocol_verify_complete) in

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -35,6 +35,7 @@ public class TCPTransport: Transport {
     private weak var delegate: TransportEventClient?
     private var isRunning = false
     private var isTLS = false
+    private var useTLS12OrGreater = false
     
     public var usingTLS: Bool {
         return self.isTLS
@@ -45,10 +46,11 @@ public class TCPTransport: Transport {
         start()
     }
     
-    public init() {
+    public init(useTLS12OrGreater: Bool = false) {
+        self.useTLS12OrGreater = useTLS12OrGreater
         //normal connection, will use the "connect" method below
     }
-    
+
     public func connect(url: URL, timeout: Double = 10, certificatePinning: CertificatePinning? = nil) {
         guard let parts = url.getParts() else {
             delegate?.connectionChanged(state: .failed(TCPTransportError.invalidRequest))
@@ -60,6 +62,10 @@ public class TCPTransport: Transport {
 
         let tlsOptions = isTLS ? NWProtocolTLS.Options() : nil
         if let tlsOpts = tlsOptions {
+            if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), useTLS12OrGreater {
+                sec_protocol_options_set_min_tls_protocol_version(tlsOpts.securityProtocolOptions, .TLSv12)
+            }
+
             sec_protocol_options_set_verify_block(tlsOpts.securityProtocolOptions, { (sec_protocol_metadata, sec_trust, sec_protocol_verify_complete) in
                 let trust = sec_trust_copy_ref(sec_trust).takeRetainedValue()
                 guard let pinner = certificatePinning else {


### PR DESCRIPTION
### Issue Link 🔗
https://wearezeta.atlassian.net/browse/WPB-4260

### Goals ⚽
Allow setting min TLS version on the web socket without introducing breaking changes.

### Implementation Details 🚧
- Define a `TLSVersion` enum
- Inject a min TLS value
- If the native engine is used, the version is set on the url session configuration.
-  If the custom engine is used, we set it on the connection.
-  Note this API is only available from certain OS versions.
